### PR TITLE
 Prevent unauthorized email address verification in the signup form

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -12,7 +12,8 @@ class UserController < ApplicationController
 
   def create
     @user_invite = UserInvite.active.find_by!(:uuid => params[:invite_token])
-    @user = User.new(params.require(:user).permit(:first_name, :last_name, :email_address, :password, :password_confirmation))
+    @user = User.new(params.require(:user).permit(:first_name, :last_name, :password, :password_confirmation))
+    @user.email_address = @user_invite.email_address
     @user.email_verified_at = Time.now
     if @user.save
       @user_invite.accept(@user)

--- a/app/views/user/new.html.haml
+++ b/app/views/user/new.html.haml
@@ -25,7 +25,7 @@
             .fieldSet__input= f.text_field :last_name, :class => 'input input--text input--onWhite'
         .fieldSet__field
           = f.label :email_address, :class => 'fieldSet__label'
-          .fieldSet__input= f.text_field :email_address, :class => 'input input--text input--onWhite'
+          .fieldSet__input= f.text_field :email_address, :class => 'input input--text input--onWhite', :disabled => true
         .fieldSet__fieldPair
           .fieldSet__field
             = f.label :password, :class => 'fieldSet__label'


### PR DESCRIPTION
Postal is verifying invitees' email address upon signing up as of this commit: 9bea99e63373393b11dd7da5cc7337bb7c9541ef

The reason is that they open the invitation link through their email address and hence have access to it. However, it's possible to change the email address in the signup form and bypass verification for the new address.