### PR TITLE
Enable https on web server

### DIFF
--- a/config/postal.defaults.yml
+++ b/config/postal.defaults.yml
@@ -18,6 +18,10 @@ web_server:
   bind_address: 127.0.0.1
   port: 5000
   max_threads: 5
+  ssl_enabled: false
+  server_key: # Defaults to config/fast_server.key
+  server_crt: # Defaults to config/fast_server.cert
+  ssl_ciphers: # Defaults TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA
 
 fast_server:
   enabled: false

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -14,9 +14,10 @@ prune_bundler
 quiet false
 
 if ssl_enabled
-	bind  "ssl://#{bind_address}:#{bind_port}?key=#{server_key}&cert=#{server_crt}&ssl_cipher_list=#{ssl_ciphers}"
+  bind  "ssl://#{bind_address}:#{bind_port}?key=#{server_key}&cert=#{server_crt}&ssl_cipher_list=#{ssl_ciphers}"
 else
-	bind  "tcp://#{bind_address}:#{bind_port}"
+  bind  "tcp://#{bind_address}:#{bind_port}"
+end
 
 unless ENV['LOG_TO_STDOUT']
   stdout_redirect Postal.log_root.join('puma.log'), Postal.log_root.join('puma.log'), true

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -3,10 +3,15 @@ threads_count = Postal.config.web_server&.max_threads&.to_i || 5
 threads         threads_count, threads_count
 bind_address  = Postal.config.web_server&.bind_address || '127.0.0.1'
 bind_port     = Postal.config.web_server&.port&.to_i || 5000
-bind            "tcp://#{bind_address}:#{bind_port}"
 environment     Postal.config.rails&.environment || 'development'
 prune_bundler
 quiet false
+
+if ssl_enabled
+	bind  "ssl://#{bind_address}:#{bind_port}?key=#{server_key}&cert=#{server_crt}&ssl_cipher_list=#{ssl_ciphers}"
+else
+	bind  "tcp://#{bind_address}:#{bind_port}"
+
 unless ENV['LOG_TO_STDOUT']
   stdout_redirect Postal.log_root.join('puma.log'), Postal.log_root.join('puma.log'), true
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,6 +4,12 @@ threads         threads_count, threads_count
 bind_address  = Postal.config.web_server&.bind_address || '127.0.0.1'
 bind_port     = Postal.config.web_server&.port&.to_i || 5000
 environment     Postal.config.rails&.environment || 'development'
+
+
+server_key =  Postal.config.web_server&.server_key  || 'config/fast_server.key'
+server_crt =  Postal.config.web_server&.server_crt || 'config/fast_server.cert'
+ssl_ciphers = Postal.config.web_server&.tls_ciphers || 'TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA'
+
 prune_bundler
 quiet false
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -5,7 +5,7 @@ bind_address  = Postal.config.web_server&.bind_address || '127.0.0.1'
 bind_port     = Postal.config.web_server&.port&.to_i || 5000
 environment     Postal.config.rails&.environment || 'development'
 
-
+ssl_enabled = Postal.config.web_server&.ssl_enabled || false
 server_key =  Postal.config.web_server&.server_key  || 'config/fast_server.key'
 server_crt =  Postal.config.web_server&.server_crt || 'config/fast_server.cert'
 ssl_ciphers = Postal.config.web_server&.tls_ciphers || 'TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA'


### PR DESCRIPTION
Enable https on web server. Certs are by default generated from: postal initialize-config / Same as for fast_server. Its simple workaround for https. Maybe there are needed some tweaks used in fast_server config.