### PR TITLE
add migration to increase links url size

### DIFF
--- a/lib/postal/message_db/migrations/19_increase_links_url_size.rb
+++ b/lib/postal/message_db/migrations/19_increase_links_url_size.rb
@@ -1,0 +1,11 @@
+module Postal
+  module MessageDB
+    module Migrations
+      class IncreaseLinksUrlSize < Postal::MessageDB::Migration
+        def up
+          @database.query("ALTER TABLE `#{@database.database_name}`.`links` MODIFY `url` TEXT")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fix for https://github.com/atech/postal/issues/668

Please note, the only way I have found to apply the migration to existing message databases is to manually run `bundle exec rake postal:migrate_message_databases`