### PR TITLE
availability to warm up ip addresses in a pool

### DIFF
--- a/app/controllers/ip_addresses_controller.rb
+++ b/app/controllers/ip_addresses_controller.rb
@@ -33,7 +33,7 @@ class IPAddressesController < ApplicationController
   private
 
   def safe_params
-    params.require(:ip_address).permit(:ipv4, :ipv6, :hostname)
+    params.require(:ip_address).permit(:ipv4, :ipv6, :hostname, :priority)
   end
 
 end

--- a/app/models/ip_address.rb
+++ b/app/models/ip_address.rb
@@ -9,6 +9,7 @@
 #  created_at :datetime
 #  updated_at :datetime
 #  hostname   :string(255)
+#  priority   :integer
 #
 
 class IPAddress < ApplicationRecord

--- a/app/models/queued_message.rb
+++ b/app/models/queued_message.rb
@@ -63,7 +63,18 @@ class QueuedMessage < ApplicationRecord
 
   def allocate_ip_address
     if Postal.ip_pools? && self.message && pool = self.server.ip_pool_for_message(self.message)
-      self.ip_address = pool.ip_addresses.order("RAND()").first
+      pool_rand = []
+      pool.ip_addresses.each do |ip|
+          prio = ip.priority ||= 0
+          (1..prio).each do |ctn|
+              pool_rand << ip.id
+          end
+      end
+      unless pool_rand.blank?
+        self.ip_address = pool.ip_addresses.find(pool_rand.sample)
+      else
+        self.ip_address = pool.ip_addresses.order("RAND()").first
+      end
     end
   end
 

--- a/app/views/ip_addresses/_form.html.haml
+++ b/app/views/ip_addresses/_form.html.haml
@@ -10,6 +10,9 @@
     .fieldSet__field
       = f.label :hostname, :class => 'fieldSet__label'
       .fieldSet__input= f.text_field :hostname, :class => 'input input--text'
+    .fieldSet__field
+      = f.label :priority, :class => 'fieldSet__label'
+      .fieldSet__input= f.text_field :priority, :class => 'input input--text'
 
   .fieldSetSubmit.buttonSet
     = f.submit :class => 'button button--positive js-form-submit'

--- a/app/views/ip_pools/_form.html.haml
+++ b/app/views/ip_pools/_form.html.haml
@@ -12,6 +12,7 @@
           %td IPv4
           %td IPv6
           %td Hostname
+          %td Priority
       %tbody
         - if @ip_pool.ip_addresses.empty?
           %tr
@@ -20,8 +21,9 @@
           - for ip in @ip_pool.ip_addresses
             %tr
               %td{:width => "20%"}= link_to ip.ipv4, [:edit, @ip_pool, ip], :class => "u-link"
-              %td{:width => "40%"}= ip.ipv6
-              %td{:width => "40%"}= ip.hostname
+              %td{:width => "35%"}= ip.ipv6
+              %td{:width => "35%"}= ip.hostname
+              %td{:width => "10%"}= ip.priority
     %p= link_to "Add an IP address to pool", [:new, @ip_pool, :ip_address], :class => "u-link"
 
 

--- a/db/migrate/20190624125018_add_priority_to_ip_addresses.rb
+++ b/db/migrate/20190624125018_add_priority_to_ip_addresses.rb
@@ -1,0 +1,5 @@
+class AddPriorityToIPAddresses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :ip_addresses, :priority, :integer
+  end
+end


### PR DESCRIPTION
This gives an availability to warm up ip addresses in a pool by setting a priority.

For example i send 5000 mails an hour and i want to warm up a new ip address by sending 1 an hour, then i set the priority of the main ip address on 4999 and the new one gets 1.
On the second day, i set it then to 500 and 1, for example, to send 10 times more emails with the new ip address, and so on and on.

It's still random and not guaranteed that the new one will send 1 email, but the possibility is there.