### PR TITLE
Add reply_to in JSON API

### DIFF
--- a/lib/postal/http_sender.rb
+++ b/lib/postal/http_sender.rb
@@ -84,7 +84,8 @@ module Postal
           :references => message.headers['references']&.last,
           :html_body => message.html_body,
           :attachment_quantity => message.attachments.size,
-          :auto_submitted => message.headers['auto-submitted']&.last
+          :auto_submitted => message.headers['auto-submitted']&.last,
+          :reply_to => message.headers['reply-to']
         }
 
         if @endpoint.strip_replies

--- a/lib/postal/http_sender.rb
+++ b/lib/postal/http_sender.rb
@@ -85,7 +85,7 @@ module Postal
           :html_body => message.html_body,
           :attachment_quantity => message.attachments.size,
           :auto_submitted => message.headers['auto-submitted']&.last,
-          :reply_to => message.headers['reply-to']
+          :reply_to => message.headers['reply-to']&.last
         }
 
         if @endpoint.strip_replies

--- a/lib/postal/http_sender.rb
+++ b/lib/postal/http_sender.rb
@@ -85,7 +85,7 @@ module Postal
           :html_body => message.html_body,
           :attachment_quantity => message.attachments.size,
           :auto_submitted => message.headers['auto-submitted']&.last,
-          :reply_to => message.headers['reply-to']&.last
+          :reply_to => message.headers['reply-to']
         }
 
         if @endpoint.strip_replies


### PR DESCRIPTION
I extended the JSON API to allow access to the `reply-to` mail header. This fixes #849.