### PR TITLE
Updated line split logic, normalize all linebreaks to \r\n

### DIFF
--- a/lib/postal/smtp_server/server.rb
+++ b/lib/postal/smtp_server/server.rb
@@ -147,15 +147,16 @@ module Postal
                   # Client went away
                   eof = true
                 end
+
+                # Normalize all \r\n and \n to \r\n
+                buffers[io] = buffers[io].encode(buffers[io].encoding, universal_newline: true).encode(buffers[io].encoding, crlf_newline: true)
+
                 # We line buffer, so look to see if we have received a newline
                 # and keep doing so until all buffered lines have been processed.
-                while buffers[io].index("\n")
+                while buffers[io].index("\r\n")
                   # Extract the line
-                  if buffers[io].index("\r\n")
-                    line, buffers[io] = buffers[io].split("\r\n", 2)
-                  else
-                    line, buffers[io] = buffers[io].split("\n", 2)
-                  end
+                  line, buffers[io] = buffers[io].split("\r\n", 2)
+
                   # Send the received line to the client object for processing
                   result = client.handle(line)
                   # If the client object returned some data, write it back to the client


### PR DESCRIPTION
Hi team,

Some emails were being rejected with error **530 From/Sender name is not valid** but it was working with different smtp servers (google, mailgun etc) and when we looked further, we could see that the @headers variable was not getting "from" field at all even through its there in the email payload. Further investigating we figured out that the message payload has inconsistent \r\n and \n and Postal was not able to parse it correctly. We could fix it by normalizing it to convert all \n and \r\n to just use \r\n on every linebreak. Please check this pull request which fixed this issue. 

Thanks