### PR TITLE
Extract client ip from X-Forwarded-For header if present

### DIFF
--- a/spec/lib/postal/fast_server/client_spec.rb
+++ b/spec/lib/postal/fast_server/client_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Postal::FastServer::Client do
+  class TestSocket
+    attr_reader :response, :peeraddr
+
+    def initialize(lines, peeraddr)
+      @lines = lines
+      @peeraddr = peeraddr
+      @line_pointer = 0
+    end
+
+    def gets
+      line = @lines[@line_pointer]
+      @line_pointer += 1
+      line
+    end
+
+    def write(response)
+      @response = response
+    end
+  end
+
+  describe '#remote_ip' do
+    it 'returns the IPv4 peer address' do
+      socket = TestSocket.new(
+        [
+          'GET / HTTP/1.1',
+          'Host: postal.mydomain.com',
+          ''
+        ],
+        ['AF_INET', 80, '221.186.184.68', '221.186.184.68']
+      )
+
+      client = Postal::FastServer::Client.new(socket, ssl: false)
+      client.run
+      expect(client.remote_ip).to eq '221.186.184.68'
+    end
+
+    it 'returns the IPv4 peer address mapped as IPV6' do
+      socket = TestSocket.new(
+        [
+          'GET / HTTP/1.1',
+          'Host: postal.mydomain.com',
+          ''
+        ],
+        ['AF_INET', 80, '::ffff:221.186.184.68', '::ffff:221.186.184.68']
+      )
+
+      client = Postal::FastServer::Client.new(socket, ssl: false)
+      client.run
+      expect(client.remote_ip).to eq '221.186.184.68'
+    end
+
+    it 'returns the peer in the X-Forwarded-For header (single value)' do
+      socket = TestSocket.new(
+        [
+          'GET / HTTP/1.1',
+          'Host: postal.mydomain.com',
+          'X-Forwarded-For: 221.186.184.68',
+          ''
+        ],
+        ['AF_INET', 80, '172.17.0.5', '172.17.0.5']
+      )
+
+      client = Postal::FastServer::Client.new(socket, ssl: false)
+      client.run
+      expect(client.remote_ip).to eq '221.186.184.68'
+    end
+
+    it 'returns the peer in the X-Forwarded-For header (multiple values)' do
+      socket = TestSocket.new(
+        [
+          'GET / HTTP/1.1',
+          'Host: postal.mydomain.com',
+          'X-Forwarded-For: 221.186.184.68, 172.17.0.0',
+          ''
+        ],
+        ['AF_INET', 80, '172.17.0.5', '172.17.0.5']
+      )
+
+      client = Postal::FastServer::Client.new(socket, ssl: false)
+      client.run
+      expect(client.remote_ip).to eq '221.186.184.68'
+    end
+  end
+
+  describe 'response' do
+    describe 'request for /'
+    it 'returns a empty response' do
+      socket = TestSocket.new(
+        [
+          'GET / HTTP/1.1',
+          'Host: postal.mydomain.com',
+          ''
+        ],
+        ['AF_INET', 80, '221.186.184.68', '221.186.184.68']
+      )
+      client = Postal::FastServer::Client.new(socket, ssl: false)
+      client.run
+
+      expect(socket.response).to eq [
+        'HTTP/1.1 200 OK',
+        '',
+        'Hello.'
+      ].join("\r\n")
+    end
+  end
+end

--- a/spec/lib/postal/fast_server/client_spec.rb
+++ b/spec/lib/postal/fast_server/client_spec.rb
@@ -39,7 +39,7 @@ describe Postal::FastServer::Client do
       expect(client.remote_ip).to eq '221.186.184.68'
     end
 
-    it 'returns the IPv4 peer address mapped as IPV6' do
+    it 'returns the IPv4 peer address mapped as IPv6' do
       socket = TestSocket.new(
         [
           'GET / HTTP/1.1',
@@ -88,24 +88,25 @@ describe Postal::FastServer::Client do
   end
 
   describe 'response' do
-    describe 'request for /'
-    it 'returns a empty response' do
-      socket = TestSocket.new(
-        [
-          'GET / HTTP/1.1',
-          'Host: postal.mydomain.com',
-          ''
-        ],
-        ['AF_INET', 80, '221.186.184.68', '221.186.184.68']
-      )
-      client = Postal::FastServer::Client.new(socket, ssl: false)
-      client.run
+    describe 'request for /' do
+      it 'returns a empty response' do
+        socket = TestSocket.new(
+          [
+            'GET / HTTP/1.1',
+            'Host: postal.mydomain.com',
+            ''
+          ],
+          ['AF_INET', 80, '221.186.184.68', '221.186.184.68']
+        )
+        client = Postal::FastServer::Client.new(socket, ssl: false)
+        client.run
 
-      expect(socket.response).to eq [
-        'HTTP/1.1 200 OK',
-        '',
-        'Hello.'
-      ].join("\r\n")
+        expect(socket.response).to eq [
+          'HTTP/1.1 200 OK',
+          '',
+          'Hello.'
+        ].join("\r\n")
+      end
     end
   end
 end


### PR DESCRIPTION
This fixes the client IP being wrong for open/click tracking when using a reverse proxy (in my case I'm running Postal in Docker, with Caddy as a HTTP and HTTPS reverse proxy).

This isn't a great solution, as the header could potentially be spoofed, but there aren't any security issues that would arise in this use case. A better solution would be to use the [ActionDispatch::RemoteIp](https://github.com/rails/rails/blob/f33d52c95217212cbacc8d5e44b5a8e3cdc6f5b3/actionpack/lib/action_dispatch/middleware/remote_ip.rb#L6-L27) middleware which has some spoofing protection.

I'm more concerned about this being a half-baked HTTP server with no tests though. Why was it done this way rather than using something standard like Puma?