### PR TITLE
Fix running postal command as non-postal user

### DIFF
--- a/bin/postal
+++ b/bin/postal
@@ -16,7 +16,7 @@ fi
 if [ $SHOULD_SUDO == "yes" ] && [ $USER != "postal" ]; then
     run() {
         HOME=/opt/postal
-        eval "sudo -u postal $@"
+        eval "sudo -E -u postal $@"
     }
 else
     run() {


### PR DESCRIPTION
resolves #338 

The `run` function makes a call to `sudo` when it decides it's not the postal user and can use `sudo`.  However, it doesn't pass the environment vars along to the new context.

#338 sets `RAILS_GROUPS` but this is lost when `sudo` is called.

```
       -E, --preserve-env
                   Indicates to the security policy that the user wishes to preserve their existing environment variables
```