### PR TITLE
temporary bypass for newer OpenSSL versions

### DIFF
--- a/lib/postal/fast_server/client.rb
+++ b/lib/postal/fast_server/client.rb
@@ -152,8 +152,11 @@ module Postal
                                 OpenSSL::SSL::OP_NO_SSLv3 |
                                 OpenSSL::SSL::OP_NO_COMPRESSION |
                                 OpenSSL::SSL::OP_CIPHER_SERVER_PREFERENCE
-          ssl_context.tmp_ecdh_callback = Proc.new do |*a|
-            OpenSSL::PKey::EC.new("prime256v1")
+
+          if ssl_context.respond_to?('tmp_ecdh_callback=')
+            ssl_context.tmp_ecdh_callback = Proc.new do |*a|
+              OpenSSL::PKey::EC.new("prime256v1")
+            end
           end
 
           unless domain_name


### PR DESCRIPTION
A possible solution for https://github.com/postalhq/postal/issues/857#issuecomment-586310259 as this callback is removed for newer versions of OpenSSL so click tracking would not work out of the box for newer Ruby versions.

I say temporary because there may be a better way of applying the option in question.

A fix here could also be a good fit for #880 as it tries to use the same callback.

Further research definitely required, I'm creating this for future reference.