### PR TITLE
James

### DIFF
--- a/api/authenticator.rb
+++ b/api/authenticator.rb
@@ -5,7 +5,7 @@ authenticator :server do
   error 'ServerSuspended', "The mail server has been suspended"
   lookup do
     if key = request.headers['X-Server-API-Key']
-      if credential = Credential.where(:type => 'API', :key => key).first
+      if credential = Credential.where(:key => key).first
         if credential.server.suspended?
           error 'ServerSuspended'
         else
@@ -19,6 +19,15 @@ authenticator :server do
   end
   rule :default, "AccessDenied", "Must be authenticated as a server." do
     identity.is_a?(Credential)
+  end
+  rule :master, "AccessDenied", "Denied By Scope." do
+    params.scope == "MASTER"
+  end
+  rule :min_scope, "AccessDenied", "Denied By Miminum Scope" do
+    current_scope = Credential::TYPES.find_index(params.scope)
+    min_scope = Credential::TYPES.find_index("API")
+
+    min_scope <= current_scope
   end
 end
 

--- a/api/controllers/credential_api_controller.rb
+++ b/api/controllers/credential_api_controller.rb
@@ -1,0 +1,136 @@
+controller :credentials do
+    friendly_name "Credentials API"
+    description "This API allows you to access Credential CRUD" 
+    authenticator :server
+  
+    action :get_limit do 
+      title "Get a Credential Limit"
+      description "This action allows you to Get a list of Credential Limit"
+      param :credential_id, "Credential Id", :required => true, :type => Integer
+
+      access_rule :master
+      action do
+        server = identity.server
+        credential = server.credentials.find_by({:id => params["credential_id"]})
+        credential.credential_limits
+      end
+    end
+  
+    action :create do 
+      title "Create a Credential"
+      description "This action allows you to create Credentials"
+      access_rule :master
+      # Acceptable Parameters
+      param :type, "Credential Type", :required => true, :type => String
+      param :name, "Credential Name", :required => true, :type => String
+      param :hold, "Send Message Status", :required => true, :type => Integer
+      param :limits, "Credential Limits", :required => true, :type => Array
+      # error
+      error 'ValidationError', "The provided data was not sufficient to create Credential", :attributes => {:errors => "A hash of error details"}
+      action do
+        server = identity.server
+        credential = server.credentials.build
+        credential.type = params["type"]
+        credential.name = params["name"]
+        credential.hold = params["hold"]
+
+        if credential.save
+          if params['limits'].present? 
+              params['limits'].each do |limit| 
+                  credential_limit = CredentialLimit.new
+                  credential_limit.credential_id = credential.id
+                  credential_limit.limit = limit["limit"].to_i
+                  credential_limit.type = limit["type"].to_s
+
+                  credential_limit.save
+              end
+          end  
+          {
+              'credential_key': credential.key,
+              'credential_id': credential.id
+          }
+        else 
+            error 'ValidationError'
+        end
+      end
+    end
+  
+    action :update do 
+      access_rule :master
+      # Acceptable Parameters
+      param :credential_id, "Credential Id", :required => true, :type => Integer
+      param :type, "Credential Type", :type => String
+      param :name, "Credential Name", :type => String
+      param :hold, "Send Message Status", :type => Integer
+      param :limits, "Credential Limits", :type => Array
+      # error
+      error 'ValidationError', "The provided data was not sufficient to update Credential", :attributes => {:errors => "A hash of error details"}
+
+      action do
+        server = identity.server
+        credential = server.credentials.find_by({:id => params["credential_id"]}) 
+        if credential.present? 
+          if params["type"].present? ||
+             params["name"].present? ||
+             params["hold"].present?
+              credential.update({
+                type: params["type"],
+                name: params["name"],
+                hold: params["hold"]
+              })
+          end
+ 
+          if params['limits'].present? 
+            params['limits'].each do |limit| 
+                credential_limit = credential.credential_limits.find_by({:type => limit["type"]})
+                if credential_limit.present?
+                  credential_limit.update({
+                    limit: limit["limit"],
+                    usage: limit["usage"]
+                  })
+                else
+                  if limit["limit"].present? && limit["type"].present?
+                    credential_limit = CredentialLimit.new
+                    credential_limit.credential_id = credential.id
+                    credential_limit.limit = limit["limit"].to_i
+                    credential_limit.type = limit["type"].to_s
+                    credential_limit.usage = limit["usage"].to_i
+
+                    credential_limit.save
+                  end
+                end
+            end
+          end 
+
+          {
+              'success': true
+          }
+        else 
+            error 'ValidationError'
+        end
+      end
+    end
+  
+    action :destroy do 
+      access_rule :master
+      # Acceptable Parameters
+      param :credential_id, "Credential Id", :required => true, :type => Integer
+      param :type, "Credential Type", :type => String
+      param :name, "Credential Name", :type => String
+      param :hold, "Send Message Status", :type => Integer
+      param :limits, "Credential Limits", :type => Array
+      # error
+      error 'ValidationError', "The provided data was not sufficient to destroy Credential", :attributes => {:errors => "A hash of error details"}
+
+      action do
+        server = identity.server
+        credential = server.credentials.find_by({:id => params["credential_id"]}) 
+        
+        if credential.present? && credential.destroy
+            {:success => true}
+        else 
+            error 'ValidationError'
+        end
+      end
+    end
+  end

--- a/api/controllers/domains_api_controller.rb
+++ b/api/controllers/domains_api_controller.rb
@@ -1,0 +1,160 @@
+controller :domains do
+  friendly_name "Domains API"
+  description "This API allows you to create and view domains on server"
+  authenticator :server
+
+  action :create do
+    title "Create a domain"
+    description "This action allows you to create domains"
+    access_rule :min_scope
+
+    param :name, "Domain name (max 50)", :required => true, :type => String
+
+    error 'ValidationError', "The provided data was not sufficient to create domain", :attributes => {:errors => "A hash of error details"}
+    error 'DomainNameMissing', "Domain name is missing"
+    error 'InvalidDomainName', "Domain name is invalid"
+    error 'DomainNameExists', "Domain name already exists"
+    error 'ReachedDomainLimit', "Domain creation has reached maximum limit"
+
+    returns Hash, :structure => :domain
+
+    action do
+      domain = identity.server.domains.find_by_name(params.name)
+      if domain.nil?
+        domain = Domain.new
+        domain.server = identity.server
+        domain.name = params.name
+        domain.verification_method = 'DNS'
+        domain.owner_type = Server
+        domain.owner_id = identity.server.id
+        domain.verified_at = Time.now
+        domain_limit = identity.credential_limits.find_by({'type' => 'domain_limit'})
+        if (domain_limit.usage.to_i != domain_limit.limit.to_i) && (domain_limit.usage.to_i < domain_limit.limit.to_i)
+          if domain.save
+            if identity.credential_limits.present?
+              if domain_limit.present?
+                usage = (domain_limmit.usage.to_i + 1)
+                domain_limit.update({"usage": usage})
+              end
+            end
+            structure :domain, domain, :return => true
+          else
+            error_message = domain.errors.full_messages.first
+            if error_message == "Name is invalid"
+              error "InvalidDomainName"
+            else
+              error "Unknown Error", error_message
+            end
+          end
+        else
+          error 'ReachedDomainLimit'
+        end
+      else
+        error 'DomainNameExists'
+      end
+
+    end
+  end
+
+  action :query do
+    title "Query domain"
+    description "This action allows you to query domain"
+    access_rule :min_scope
+
+    param :name, "Domain name (max 50)", :required => true, :type => String
+
+    error 'ValidationError', "The provided data was not sufficient to query domain", :attributes => {:errors => "A hash of error details"}
+    error 'DomainNameMissing', "Domain name is missing"
+    error 'DomainNotFound', "The domain not found"
+
+    returns Hash, :structure => :domain
+
+    action do
+      domain = identity.server.domains.find_by_name(params.name)
+      if domain.nil?
+        error 'DomainNotFound'
+      else
+        structure :domain, domain, :return => true
+      end
+    end
+  end
+
+  action :check do
+    title "Check domain status"
+    description "This action allows you to check domain status"
+    access_rule :min_scope
+
+    param :name, "Domain name (max 50)", :required => true, :type => String
+
+    error 'ValidationError', "The provided data was not sufficient to query domain", :attributes => {:errors => "A hash of error details"}
+    error 'DomainNameMissing', "Domain name is missing"
+    error 'DomainNotFound', "The domain not found"
+
+    returns Hash, :structure => :domain
+
+    action do
+      domain = identity.server.domains.find_by_name(params.name)
+      if domain.nil?
+        error 'DomainNotFound'
+      else
+        domain.check_dns(:manual)
+        structure :domain, domain, :return => true
+      end
+    end
+  end
+
+  action :delete do
+    title "Delete a domain"
+    description "This action allows you to delete domain"
+    access_rule :min_scope
+
+    param :name, "Domain name (max 50)", :required => true, :type => String
+
+    error 'ValidationError', "The provided data was not sufficient to query domain", :attributes => {:errors => "A hash of error details"}
+    error 'DomainNameMissing', "Domain name is missing"
+    error 'DomainNotFound', "The domain not found"
+    error 'DomainNotDeleted', "Domain could not be deleted"
+
+    returns Hash
+
+    action do
+      domain = identity.server.domains.find_by_name(params.name)
+      if domain.nil?
+        error 'DomainNotFound'
+      elsif domain.delete
+        if identity.credential_limits.present?
+          domain_limit = identity.credential_limits.find_by({'type' => 'domain_limit'})
+          if domain_limit.present?
+            usage = (domain_limmit.usage.to_i - 1)
+            usage = 0 if usage < 0
+            domain_limit.update({"usage": usage})
+          end
+        end
+        {:message => "Domain deleted successfully"}
+      else
+        error 'DomainNotDeleted'
+      end
+    end
+  end
+
+  action :get_all do
+    title "Get All domain"
+    description "TGet All domains with associated credential"
+    access_rule :min_scope
+
+    error 'DomainNull', "No Domain Found with the credential", :attributes => {:errors => "A hash of error details"}
+ 
+
+    returns Hash
+
+    action do
+      domains = identity.domains
+      if domains.present?
+        domains
+      else
+        error 'DomainNull'
+      end
+    end
+  end
+
+end

--- a/api/structures/domain_api_structure.rb
+++ b/api/structures/domain_api_structure.rb
@@ -1,0 +1,41 @@
+structure :domain do
+  basic :id, :type => Integer
+  basic :uuid, :type => String
+  basic :name, :type => String
+  basic :server_id, :type => Integer
+
+  group :verification do
+    basic :verification_token, :type => String
+    basic :verification_method, :type => String
+  end
+
+  basic :created_at, :type => String
+  basic :updated_at, :type => String
+  basic :dns_checked_at, :type => String
+  basic :owner_id, :type => Integer
+  basic :owner_type, :type => String
+
+  group :spf do
+    basic :spf_record, :type => String
+    basic :spf_status, :type => String
+    basic :spf_error, :type => String
+  end
+
+  group :dkim do
+    basic :dkim_record_name, :type => String
+    basic :dkim_record, :type => String
+    basic :dkim_status, :type => String
+    basic :dkim_error, :type => String
+  end
+
+  group :mx_record do
+    basic :mx_status, :type => String
+    basic :mx_error, :type => String
+  end
+
+  group :return_path do
+    basic :return_path_domain, :type => String
+    basic :return_path_status, :type => String
+    basic :return_path_error, :type => String
+  end
+end

--- a/app/models/credential.rb
+++ b/app/models/credential.rb
@@ -17,8 +17,10 @@
 class Credential < ApplicationRecord
 
   belongs_to :server
+  has_many :credential_limits
+  has_many :domains
 
-  TYPES = ['SMTP', 'API']
+  TYPES = ['SMTP', 'API', 'MASTER']
 
   validates :key, :presence => true, :uniqueness => true
   validates :type, :inclusion => {:in => TYPES}

--- a/app/models/credential_limit.rb
+++ b/app/models/credential_limit.rb
@@ -1,0 +1,13 @@
+# == Schema Information
+#
+# Table name: credential_limits
+#
+#  id           :integer          not null, primary key
+#  credential_id    :integer
+#  type          :string(255)
+#  limit         :integer
+#  usage         :integer
+#
+class CredentialLimit < ApplicationRecord
+    belongs_to :credential
+end

--- a/db/migrate/20200312170719_create_credential_limits.rb
+++ b/db/migrate/20200312170719_create_credential_limits.rb
@@ -1,0 +1,10 @@
+class CreateCredentialLimits < ActiveRecord::Migration[5.2]
+  def change
+    create_table :credential_limits, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"  do |t|
+      t.integer :credential_id
+      t.string :type
+      t.integer :limit
+      t.integer :usage
+    end
+  end
+end

--- a/db/migrate/20200312171711_add_column_credential_id_to_domains.rb
+++ b/db/migrate/20200312171711_add_column_credential_id_to_domains.rb
@@ -1,0 +1,5 @@
+class AddColumnCredentialIdToDomains < ActiveRecord::Migration[5.2]
+  def change
+    add_column :domains, :credential_id, :integer
+  end
+end

--- a/spec/api/controllers/domains_api_controller_spec.rb
+++ b/spec/api/controllers/domains_api_controller_spec.rb
@@ -1,0 +1,174 @@
+_require 'rails_helper'
+require './spec/api/controllers/domains_init'
+
+
+describe "Domains API" do
+  domain_valid = "cloudy.com"
+  domain_invalid = "test domain"
+  url_create = "/api/v1/domains/create"
+  url_query = "/api/v1/domains/query"
+  url_check = "/api/v1/domains/check"
+  url_delete = "/api/v1/domains/delete"
+
+  @credential = nil
+  @domain_init = nil
+  api_key = nil
+
+  before(:all) do
+    puts "about to prepare..."
+    @domain_init = DomainsInit.new
+    @domain_init.prepare
+    @credential = @domain_init.get_credential
+    api_key = @credential.key
+  end
+
+  after(:all) do
+    puts "about to tear down..."
+    @domain_init.tear_down
+  end
+
+  describe "Create Domain" do
+    describe "Create domain request Without api token" do
+      it "rejects to create domain" do
+        post url_create, params: {name:"My Domain"}
+        expect(response).to have_http_status(:success)
+        hash_body = nil
+        expect { hash_body = JSON.parse(response.body).with_indifferent_access }.not_to raise_exception
+        #puts hash_body
+        expect(hash_body[:status]).to match("error")
+        expect(hash_body[:data][:code]).to match("AccessDenied")
+      end
+    end
+
+    describe "Create domain request with Invalid domain name" do
+      it("rejects invalid domain name"){
+        params = {:name => "test domain"}
+        post url_create, params: params, headers: {"X-Server-API-Key":api_key}, as: :json
+        hash_body = nil
+        expect { hash_body = JSON.parse(response.body).with_indifferent_access }.not_to raise_exception
+        #puts hash_body
+        expect(response).to have_http_status(:success)
+        expect(hash_body[:status]).to match("error")
+        expect(hash_body[:data][:code]).to match("InvalidDomainName")
+      }
+    end
+
+    describe "Create Domain with api key" do
+      it "create a new domain" do
+        params = {:name => domain_valid}
+        post url_create, params: params, headers: {"X-Server-API-Key":api_key}, as: :json
+        hash_body = nil
+        expect { hash_body = JSON.parse(response.body).with_indifferent_access }.not_to raise_exception
+        #puts hash_body
+        expect(response).to have_http_status(:success)
+        expect(hash_body[:status]).to match("success")
+        expect(hash_body[:data][:name]).to match(domain_valid)
+      end
+    end
+
+  end
+
+  describe "Actions on  existing domain" do
+    before(:all) do
+      params = {:name => domain_valid}
+      post url_create, params: params, headers: {"X-Server-API-Key":api_key}, as: :json
+      #puts response.body
+    end
+
+    describe "Create a duplicate domain" do
+      it "rejects to create another domain with the same name" do
+        params = {:name => domain_valid}
+        post url_create, params: params, headers: {"X-Server-API-Key":api_key}, as: :json
+        hash_body = nil
+        expect { hash_body = JSON.parse(response.body).with_indifferent_access }.not_to raise_exception
+        #puts hash_body
+        expect(response).to have_http_status(:success)
+        expect(hash_body[:status]).to match("error")
+        expect(hash_body[:data][:code]).to match("DomainNameExists")
+      end
+    end
+
+    describe "Query Domain" do
+
+      describe "Query domain without api key" do
+        it "Rejects without api key" do
+          params = {:name => domain_valid}
+          post url_query, params: params, as: :json
+          hash_body = nil
+          expect { hash_body = JSON.parse(response.body).with_indifferent_access }.not_to raise_exception
+          #puts hash_body
+          expect(response).to have_http_status(:success)
+          expect(hash_body[:status]).to match("error")
+          expect(hash_body[:data][:code]).to match("AccessDenied")
+        end
+      end
+
+      describe "Query for non-existent domain" do
+        it "Returns NotFound response" do
+          params = {:name => domain_invalid}
+          post url_query, params: params, headers: {"X-Server-API-Key":api_key}, as: :json
+          hash_body = nil
+          expect { hash_body = JSON.parse(response.body).with_indifferent_access }.not_to raise_exception
+          #puts hash_body
+          expect(response).to have_http_status(:success)
+          expect(hash_body[:status]).to match("error")
+          expect(hash_body[:data][:code]).to match("NotFound")
+        end
+      end
+
+      describe "Query with api key" do
+
+        it "Returns domain" do
+          params = {:name => domain_valid}
+          post url_query, params: params, headers: {"X-Server-API-Key":api_key}, as: :json
+          hash_body = nil
+          expect { hash_body = JSON.parse(response.body).with_indifferent_access }.not_to raise_exception
+          #puts hash_body
+          expect(response).to have_http_status(:success)
+          expect(hash_body[:status]).to match("success")
+          expect(hash_body[:data][:name]).to match(domain_valid)
+        end
+      end
+    end
+
+    describe "Check Domain status" do
+      it "returns domain" do
+        params = {:name => domain_valid}
+        post url_check, params: params, headers: {"X-Server-API-Key":api_key}, as: :json
+        hash_body = nil
+        expect { hash_body = JSON.parse(response.body).with_indifferent_access }.not_to raise_exception
+        #puts hash_body
+        expect(response).to have_http_status(:success)
+        expect(hash_body[:status]).to match("success")
+        expect(hash_body[:data][:name]).to match(domain_valid)
+      end
+    end
+
+    describe "Delete Domain" do
+
+      it "deletes domain" do
+        params = {:name => domain_valid}
+        post url_delete, params: params, headers: {"X-Server-API-Key":api_key}, as: :json
+        #puts response.body
+
+        hash_body = nil
+        expect { hash_body = JSON.parse(response.body).with_indifferent_access }.not_to raise_exception
+        expect(response).to have_http_status(:success)
+        expect(hash_body[:status]).to match("success")
+        expect(hash_body[:data][:message]).to match("Domain deleted successfully")
+      end
+
+      it "returns NotFound response" do
+        params = {:name => domain_invalid}
+        post url_delete, params: params, headers: {"X-Server-API-Key":api_key}, as: :json
+        #puts response.body
+
+        hash_body = nil
+        expect { hash_body = JSON.parse(response.body).with_indifferent_access }.not_to raise_exception
+        expect(response).to have_http_status(:success)
+        expect(hash_body[:status]).to match("error")
+        expect(hash_body[:data][:code]).to match("DomainNotFound")
+      end
+    end
+  end
+end

--- a/spec/api/controllers/domains_init.rb
+++ b/spec/api/controllers/domains_init.rb
@@ -1,0 +1,124 @@
+class DomainsInit < ApplicationController
+
+    def initialize
+      puts "Initializing DomainsInit"
+      @user_email = "john.doe@example.com"
+      @org_name = "Mailer Organization"
+      @org_permalink = "mailer-orgs"
+      @server_name = "Mailer Server"
+      @server_permalink = "mailer-server"
+      @cred_name = "Mailer Credentials"
+  
+      @user = User.find_by_email_address(@user_email)
+      @organization = Organization.find_by_permalink(@org_permalink)
+      @server = Server.find_by_permalink(@server_permalink)
+      @credential = Credential.find_by_name(@cred_name)
+    end
+  
+    def prepare
+      if @user.nil?
+        @user = create_user
+      end
+  
+      if @organization.nil?
+        @organization = create_organization
+      end
+  
+      if @server.nil?
+        @server = create_server
+      end
+  
+      if @credential.nil?
+        @credential = create_credential
+      end
+    end
+  
+    def create_user
+      user = User.new
+      user.email_address = @user_email
+      user.first_name = "John"
+      user.last_name = "Doe"
+      user.password = "john.doe_123"
+      user.email_verified_at = Time.now
+      if user.save
+        puts "User created"
+        user
+      else
+        puts "User could not be created"
+        put_errors user.errors.full_messages
+      end
+    end
+  
+    def create_organization
+      organization = Organization.new
+      organization.name = @org_name
+      organization.permalink = @org_permalink
+      organization.owner = @user
+      if organization.save
+        puts "Organization created"
+        organization
+      else
+        puts "Could not create Organization"
+        put_errors organization.errors.full_messages
+      end
+    end
+  
+    def create_server
+      server = Server.new
+      server.organization = @organization
+      server.name = @server_name
+      server.permalink = @server_permalink
+      server.mode = "Development"
+      if server.save
+        puts "Server created"
+        server
+      else
+        puts "Server could not be created"
+        put_errors server.errors.full_messages
+      end
+    end
+  
+    def create_credential
+      cred = Credential.new
+      cred.name = @cred_name
+      cred.server = @server
+      cred.type = "API"
+      if cred.save
+        puts "Credential created"
+        cred
+      else
+        puts "Could not create credential"
+        put_errors cred.errors.full_messages
+      end
+    end
+  
+    def get_credential
+      @credential
+    end
+  
+    def tear_down
+      unless @credential.delete
+        put_errors @credential.errors.full_messages
+      end
+      unless @server.delete
+        put_errors @server.errors.full_messages
+      end
+      unless @organization.delete
+        put_errors @organization.errors.full_messages
+      end
+      unless @user.delete
+        put_errors @user.errors.full_messages
+      end
+    end
+  
+    def get_organization
+      @organization
+    end
+  
+    private
+    def put_errors(errors)
+      for error in errors
+        puts " * #{error}"
+      end
+    end
+  end


### PR DESCRIPTION
Add postal usage limitation via REST API Endpoint.

notes:
- Api Authenticator:
  - min_scope: it will depends on 'API' index in Credential::TYPES array.
    currently, Credential::TYPES = ['SMTP', 'API', 'MASTER']
    since, API on index 1, 'SMTP' on index 0 will not have access to the API.
   
   this feature, implemented for Domain Endpoint