### PR TITLE
Make the smtp_server listen IP configurable

### DIFF
--- a/config/postal.defaults.yml
+++ b/config/postal.defaults.yml
@@ -71,6 +71,7 @@ workers:
   threads: 4
 
 smtp_server:
+  host: 127.0.0.1 ## This should be the IP address that Postal will listen on for incoming SMTP connections
   port: 25
   tls_enabled: false
   tls_certificate_path: # Defaults to config/smtp.cert

--- a/lib/postal/smtp_server/server.rb
+++ b/lib/postal/smtp_server/server.rb
@@ -49,7 +49,7 @@ module Postal
         if ENV['SERVER_FD']
           @server = TCPServer.for_fd(ENV['SERVER_FD'].to_i)
         else
-          @server = TCPServer.open('::', Postal.config.smtp_server.port)
+          @server = TCPServer.open(Postal.config.smtp_server.host, Postal.config.smtp_server.port)
         end
         @server.autoclose = false
         @server.close_on_exec = false


### PR DESCRIPTION
When there are multiple IPs on a server and other SMTP servers are listening for connections on other IP addresses, Postal can't bind to `:::`. In such a case, the IP to bind to can be provided in the config file so that Postal does not give an error. The IP in the configuration can also be `0.0.0.0` to reflect the default behaviour.