### PR TITLE
Add log line for failed authentication attempts

### DIFF
--- a/lib/postal/smtp_server/client.rb
+++ b/lib/postal/smtp_server/client.rb
@@ -196,6 +196,7 @@ module Postal
           @credential.use
           "235 Granted for #{@credential.server.organization.permalink}/#{@credential.server.permalink}"
         else
+          log "\e[33m   WARN: AUTH failure for #{@ip_address}\e[0m"
           "535 Invalid credential"
         end
       end


### PR DESCRIPTION
This PR fixes #1182. In short, programs such as fail2ban rely on logs with events and IP addresses. This extra log entry makes it much easier to implement a regex for fail2ban.

I'm now working on a proper fail2ban jail configuration, I can commit that too if desired.