### PR TITLE
Do not find the original message when returning batchable messages

### DIFF
--- a/app/models/queued_message.rb
+++ b/app/models/queued_message.rb
@@ -111,7 +111,7 @@ class QueuedMessage < ApplicationRecord
       time = Time.now
       locker = Postal.locker_name
       self.class.retriable.where(:batch_key => self.batch_key, :ip_address_id => self.ip_address_id, :locked_by => nil, :locked_at => nil).limit(limit).update_all(:locked_by => locker, :locked_at => time)
-      QueuedMessage.where(:batch_key => self.batch_key, :ip_address_id => self.ip_address_id, :locked_by => locker, :locked_at => time)
+      QueuedMessage.where(:batch_key => self.batch_key, :ip_address_id => self.ip_address_id, :locked_by => locker, :locked_at => time).where.not(id: self.id)
     end
   end
 


### PR DESCRIPTION
This fixes a bug where a message is locked, and when within the same 1-second window, batchable messages are found, including the original message.