### PR TITLE
remove unnecessary check as organizations can be deleted by admins

### DIFF
--- a/app/views/organizations/_nav.html.haml
+++ b/app/views/organizations/_nav.html.haml
@@ -7,5 +7,4 @@
       - if Postal.ip_pools?
         %li.navBar__item= link_to "IPs", organization_ip_pools_path(organization), :class => ['navBar__link', active_nav == :ips ? 'is-active' : '']
       %li.navBar__item= link_to "Users", organization_users_path(organization), :class => ['navBar__link', active_nav == :users ? 'is-active' : '']
-      - if organization.owner?(current_user)
-        %li.navBar__item= link_to "Delete Organization", organization_delete_path(organization), :class => ['navBar__link', active_nav == :delete ? 'is-active' : '']
+      %li.navBar__item= link_to "Delete Organization", organization_delete_path(organization), :class => ['navBar__link', active_nav == :delete ? 'is-active' : '']


### PR DESCRIPTION
In doing some long-overdue cleanup of our postal server, we noticed that the Delete Organization link was being hidden from other admin users but the controller only checks for admin, not owner, so removing this check was the most appropriate solution.

We could have added an owner check to the controller but in the absence of other user management in the UI, it would have become annoying to overcome.