### PR TITLE
Fix check for secure socket in SMTP extensions (Fixes #1336)

### DIFF
--- a/config/initializers/smtp_extensions.rb
+++ b/config/initializers/smtp_extensions.rb
@@ -8,7 +8,7 @@ class Net::SMTP
   attr_accessor :source_address
 
   def secure_socket?
-    @socket.is_a?(OpenSSL::SSL::SSLSocket)
+    @socket.io.is_a?(OpenSSL::SSL::SSLSocket)
   end
 
   #


### PR DESCRIPTION
This PR fixes the check if the SMTP connection uses a secure socket. Before it directly checks the `socket` field, however this is actually an `InternetMessageIO` object which inherits from `BufferedIO`, so you need to access the `io` field from `BufferedIO` to actually access the 'real' SSL socket.

This also means we finally see the padlock next to the sent status!

Before:
![Screenshot 2021-04-07 001322](https://user-images.githubusercontent.com/7677699/113784917-76144480-9736-11eb-998f-a7924dbedf61.png)

After:
![Screenshot 2021-04-08 003606](https://user-images.githubusercontent.com/7677699/113943243-8d206880-9802-11eb-8f7d-404a4b91513b.png)


This fixes #1336