### PR TITLE
README: Replace Google Groups with Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ The application has been running in production for us for nearly 6 months and we
 * [Quick install guide](https://github.com/atech/postal/wiki/Quick-Install)
 * [Installation docs](https://github.com/atech/postal/wiki/Installation)
 * [FAQs](https://github.com/atech/postal/wiki/FAQs) & [Features](https://github.com/atech/postal/wiki/Features)
-* [Google Group](https://groups.google.com/forum/#!forum/postal-talk) - for support, questions or comments.
+* [Slack Channel](https://slack.k.io/) - for live support, questions or comments.


### PR DESCRIPTION
# Problem
* The README is listing Google Groups for support

# What this PR includes
* I simply removed Google Groups and replaced it with the link from this comment: https://github.com/postalhq/postal/issues/917#issuecomment-615157381