### PR TITLE
Issue Templates: Add link on where to get support & suggest features

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,5 +1,5 @@
 ---
-name: Bug report
+name: 🐛 Bug report
 about: Create a report to help us improve Postal and fix issues.
 title: ''
 labels: bug

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: 🙏 Help and Support
+    url: https://github.com/postalhq/postal/discussions/new?category=Help-and-Support
     about: Get friendly support from the community on Github Discussions.
+
+  

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,4 +4,6 @@ contact_links:
     url: https://github.com/postalhq/postal/discussions/new?category=Help-and-Support
     about: Get friendly support from the community on Github Discussions.
 
-  
+  - name: 🦊 Feature Suggestions
+    url: https://github.com/postalhq/postal/discussions/new?category=Feature-Suggestions
+    about: Suggest a new feature that should be added to Postal.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,4 @@
 blank_issues_enabled: false
 contact_links:
-  - name: ❓ Support Question
-    url: https://github.com/postalhq/postal/discussions
+  - name: 🙏 Help and Support
     about: Get friendly support from the community on Github Discussions.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: ❓ Support Question
+    url: https://github.com/postalhq/postal/discussions
+    about: Get friendly support from the community on Github Discussions.


### PR DESCRIPTION
# Problem
* People are used to creating issues for support, so they will pollute issues with support questions by habit

# What this PR does
* I created links from the issue template that will automatically guide the user to compose a new message on Github Discussions (based off of what they select)
* This also disables blank templates (so people are force to use the provided templates)

# What this looks like
![image](https://user-images.githubusercontent.com/3174134/127240155-477fad4e-96a8-415a-87aa-143515843e9b.png)

# Where you can test it
You can see the working example on my fork: https://github.com/serversideup/postal/issues/new/choose